### PR TITLE
Fix/enable auto rollback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - fix/enable-auto-rollback
     tags:        # ← NEW: Trigger on version tags
       - 'v*'
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix/enable-auto-rollback
     tags:        # ← NEW: Trigger on version tags
       - 'v*'
   pull_request:

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -3,3 +3,4 @@
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 #Because was crashing on ota reboot saying "A stack overflow in task sys_evt has been detected"
 CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y


### PR DESCRIPTION
The CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE is set in the sdkconfig.defaults. Then sdkconfig was deleted and project was rebuit to have the sdkconfig regenerated (although it could have been regenerated in a simple way). Then idf.py bootloader-flash  was used to flash new bootloader according to the new sdkconfig. 
Now at reboot the pending verification state is seen in the if condition. 
The intermediate boot occuring bcz of crash caused by wifi is not registered as a reboot