### PR TITLE
fix: wifi smartconfig route restart problem

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -30,7 +30,7 @@ dependencies:
 
   wifi-smartconfig:
     git: https://github.com/khiyamiftikhar/wifi-smartconfig
-    #version: fix/power-outage-behavior
+    version: fix/connect-on-router-restart
   event-adapter:
     git: https://github.com/khiyamiftikhar/event-adapter
 


### PR DESCRIPTION
Fixed:

The smartconfig component had a bug. on router disconnect it went to init state where it waited for init bit forever which which was cleared on last wait (boot), and will never be set again unless restart.
Now goes to stored credentials connection attempt state